### PR TITLE
CM for chains

### DIFF
--- a/scOOP/mc/movecreator.cpp
+++ b/scOOP/mc/movecreator.cpp
@@ -1692,13 +1692,6 @@ double MoveCreator::clusterMoveGeom(long target) {
         conf->geo.usePBC(&reflection);
 
         // bring reflected particle into box (if not particles could start to spread too far and numerical errors acumulate!)
-        //
-        // well usePBC cant be used directly now since in cluster rotete calculation of center of mass of particle assume that particles are nex to each other
-        // and does not take PBC condition into account ... use of PBC would lead to splliting particles on sides of box and then to wrong calculation of CM of cluster
-        // leading to wrong rotation changing distances between particles in cluster and creating large drift....
-        //
-        // I have tested that drift comming out of not using PBC in clusterMove is not that large however particles with larger difusivity might cause problems so
-        // it would be better to make chains whole after reflection or change CM calculation
 
         //Iterate through reflection "Neighbours"
         for (unsigned int i = 0; i < conf->pvec.size(); i++){
@@ -1728,7 +1721,6 @@ double MoveCreator::clusterMoveGeom(long target) {
         counter++;
     }while(counter < num_particles);
     for ( std::vector<Molecule>::iterator it = chainsToFix.begin(); it != chainsToFix.end(); ++it ){
-//        cout << it->info() << endl;
         conf->makeMoleculeWhole(&(*it));
     }
     return calcEnergy->allToAll()-edriftchanges;

--- a/scOOP/scOOP.pro
+++ b/scOOP/scOOP.pro
@@ -8,18 +8,18 @@ QMAKE_CXXFLAGS += -O3 -msse2 -mfpmath=sse  #-g -fno-inline
 #QMAKE_CXXFLAGS+= -fopenmp
 #QMAKE_LFLAGS +=  -fopenmp
 
-QMAKE_CXXFLAGS += -DENABLE_MPI
+#QMAKE_CXXFLAGS += -DENABLE_MPI
 
-QMAKE_CXX = mpicxx
-QMAKE_CXX_RELEASE = $$QMAKE_CXX
-QMAKE_CXX_DEBUG = $$QMAKE_CXX
-QMAKE_LINK = $$QMAKE_CXX
-QMAKE_CC = mpicc
+#QMAKE_CXX = mpicxx
+#QMAKE_CXX_RELEASE = $$QMAKE_CXX
+#QMAKE_CXX_DEBUG = $$QMAKE_CXX
+#QMAKE_LINK = $$QMAKE_CXX
+#QMAKE_CC = mpicc
 
-QMAKE_CFLAGS += $$system(mpicc --showme:compile)
-QMAKE_LFLAGS += $$system(mpicxx --showme:link)
-QMAKE_CXXFLAGS += $$system(mpicxx --showme:compile) -DMPICH_IGNORE_CXX_SEEK
-QMAKE_CXXFLAGS_RELEASE += $$system(mpicxx --showme:compile) -DMPICH_IGNORE_CXX_SEEK
+#QMAKE_CFLAGS += $$system(mpicc --showme:compile)
+#QMAKE_LFLAGS += $$system(mpicxx --showme:link)
+#QMAKE_CXXFLAGS += $$system(mpicxx --showme:compile) -DMPICH_IGNORE_CXX_SEEK
+#QMAKE_CXXFLAGS_RELEASE += $$system(mpicxx --showme:compile) -DMPICH_IGNORE_CXX_SEEK
 
 
 SOURCES += main.cpp \

--- a/scOOP/scOOP.pro
+++ b/scOOP/scOOP.pro
@@ -8,18 +8,18 @@ QMAKE_CXXFLAGS += -O3 -msse2 -mfpmath=sse  #-g -fno-inline
 #QMAKE_CXXFLAGS+= -fopenmp
 #QMAKE_LFLAGS +=  -fopenmp
 
-#QMAKE_CXXFLAGS += -DENABLE_MPI
+QMAKE_CXXFLAGS += -DENABLE_MPI
 
-#QMAKE_CXX = mpicxx
-#QMAKE_CXX_RELEASE = $$QMAKE_CXX
-#QMAKE_CXX_DEBUG = $$QMAKE_CXX
-#QMAKE_LINK = $$QMAKE_CXX
-#QMAKE_CC = mpicc
+QMAKE_CXX = mpicxx
+QMAKE_CXX_RELEASE = $$QMAKE_CXX
+QMAKE_CXX_DEBUG = $$QMAKE_CXX
+QMAKE_LINK = $$QMAKE_CXX
+QMAKE_CC = mpicc
 
-#QMAKE_CFLAGS += $$system(mpicc --showme:compile)
-#QMAKE_LFLAGS += $$system(mpicxx --showme:link)
-#QMAKE_CXXFLAGS += $$system(mpicxx --showme:compile) -DMPICH_IGNORE_CXX_SEEK
-#QMAKE_CXXFLAGS_RELEASE += $$system(mpicxx --showme:compile) -DMPICH_IGNORE_CXX_SEEK
+QMAKE_CFLAGS += $$system(mpicc --showme:compile)
+QMAKE_LFLAGS += $$system(mpicxx --showme:link)
+QMAKE_CXXFLAGS += $$system(mpicxx --showme:compile) -DMPICH_IGNORE_CXX_SEEK
+QMAKE_CXXFLAGS_RELEASE += $$system(mpicxx --showme:compile) -DMPICH_IGNORE_CXX_SEEK
 
 
 SOURCES += main.cpp \

--- a/scOOP/structures/Conf.h
+++ b/scOOP/structures/Conf.h
@@ -329,6 +329,18 @@ public:
         return sqrt(distSq(part1,part2));
     }
 
+    void makeMoleculeWhole( Molecule *mol ){
+        Vector r_cm;
+        std::vector<int>::iterator first = mol->begin();
+        for ( std::vector<int>::iterator it = first+1 ; it != mol->end() ; ++it ){
+            r_cm = geo.image( &pvec[(*it)].pos, &pvec[(*first)].pos );
+            geo.usePBC( r_cm );
+//            cout << "pos of 0:" << pvec[(*first)].pos.info() << " | pos of second: " << pvec[(*it)].pos.info() << endl;
+//            cout << "r_cm: " << r_cm.info() << endl;
+            pvec[(*it)].pos = pvec[(*first)].pos + r_cm;
+        }
+    }
+
     /**
      * @brief draw Dumps a configuration to the supplied file handle.
      * @param outfile

--- a/scOOP/structures/Conf.h
+++ b/scOOP/structures/Conf.h
@@ -329,6 +329,12 @@ public:
         return sqrt(distSq(part1,part2));
     }
 
+    /**
+     * @brief makeMoleculeWhole
+     * Function move all particles in Molecule (*mol) to be directly next to first particle in molecule.
+     * In other words function restore Molecule to be in one pice if molecule were broken by using PBC.
+     * @param *mol
+     */
     void makeMoleculeWhole( Molecule *mol ){
         Vector r_cm;
         std::vector<int>::iterator first = mol->begin();

--- a/scOOP/structures/Conf.h
+++ b/scOOP/structures/Conf.h
@@ -335,8 +335,6 @@ public:
         for ( std::vector<int>::iterator it = first+1 ; it != mol->end() ; ++it ){
             r_cm = geo.image( &pvec[(*it)].pos, &pvec[(*first)].pos );
             geo.usePBC( r_cm );
-//            cout << "pos of 0:" << pvec[(*first)].pos.info() << " | pos of second: " << pvec[(*it)].pos.info() << endl;
-//            cout << "r_cm: " << r_cm.info() << endl;
             pvec[(*it)].pos = pvec[(*first)].pos + r_cm;
         }
     }

--- a/scOOP/structures/Vector.h
+++ b/scOOP/structures/Vector.h
@@ -80,6 +80,10 @@ public:
         return Vector(x-o.x, y-o.y,z-o.z);
     }
 
+    inline Vector operator+ ( const Vector &o ){
+        return Vector( x + o.x, y + o.y, z + o.z );
+    }
+
     inline void operator-= (const Vector& o) {
         x-=o.x;
         y-=o.y;

--- a/scOOP/structures/geometry.h
+++ b/scOOP/structures/geometry.h
@@ -36,7 +36,7 @@ public:
     }
 
     /**
-     * @brief use of periodic boundary conditions
+     * @brief Use of periodic boundary conditions on Particle
      * @param pos
      * @param pbc
      */ 
@@ -62,8 +62,22 @@ public:
     }
 
     /**
+     * @brief usePBC
+     * Function normalise vector by box size to fit in range [0;1].
+     * In other words distnaces or positions in real coordinates are translated into internal coordinates which are normalised by box size.
+     * @param vec - pointer to vector in real coordinates
+     */
+    void usePBC( Vector &vec ){
+        vec.x /= box.x;
+        vec.y /= box.y;
+        vec.z /= box.z;
+    }
+
+    /**
      * @brief Returns the vector pointing from the centre of mass of particle 2 to the
        centre of mass of the closest image of particle 1.
+       BECAREFULL r_cm vector is in real values ... in other words when you use image finction
+       in code u have to normalize it by box size!!
      * @param r1
      * @param r2
      * @param box

--- a/scOOP/structures/structures.h
+++ b/scOOP/structures/structures.h
@@ -19,7 +19,18 @@ typedef struct{
     long * particles;
 } Cluster;
 
-class Molecule : public vector<int > {};
+class Molecule : public vector<int > {
+public:
+    std::string info(){
+        std::ostringstream o;
+        o << "[";
+        for ( unsigned int i = 0; i < this->size()-1; i++ ){
+            o << this->operator [](i) << ", ";
+        }
+        o << this->operator [](this->size()-1) << "]";
+        return o.str();
+    }
+};
 
 /**
  * @brief This structure is for io only


### PR DESCRIPTION
Well now problem with breaking molecule on PBC in CM after usePBC() is fixed by addition of for loop in the end of CM when direct connectivity of molecules is restored.

Simulations were tested on longer runs on larger system (10 000 000 sweep 600 particles chain size 2 all moves except for GC was used) and with test scripts.
