### PR TITLE
Fix of TCPSC and CM+init bug

### DIFF
--- a/scOOP/mc/movecreator.cpp
+++ b/scOOP/mc/movecreator.cpp
@@ -1680,7 +1680,7 @@ double MoveCreator::clusterMoveGeom(long target) {
         reflection = conf->pvec[cluster[counter]];// copy old particle into reflected particle
         //Reflect particle cluster[counter] by point reflection by center r_center point
         reflection.pos           = 2.0*r_center - reflection.pos;// reflect center of particle around r_center
-        reflection.dir          *=-1.0;// reflect orientation of particle
+        reflection.dir          *=1.0;// reflect orientation of particle
         reflection.patchdir[0]  *=-1.0;// reflect orientation of patch1
         reflection.patchdir[1]  *=-1.0;// reflect orientation of patch2
         reflection.patchsides[0]*=-1.0;// reflect all sides of patch


### PR DESCRIPTION
In short when particles get reflected its handenes was changed so that when in initialization orientation of second patch was created by rotation of first patch wrong orientation of second patch was created so drift arise.
