### PR TITLE
Fix other instances of wrong use of temperature in tranlation entropy

### DIFF
--- a/scOOP/mc/movecreator.cpp
+++ b/scOOP/mc/movecreator.cpp
@@ -483,7 +483,7 @@ double MoveCreator::replicaExchangeMove(long sweep) {
     double change; // energy
     double *recwlweights;
     double volume = conf->geo.volume();
-    double entrophy = sim->press * volume - (double)conf->pvec.size() * log(volume) / sim->temper;
+    double entrophy = sim->press * volume - (double)conf->pvec.size() * log(volume) * sim->temper;
 
     int sizewl = 0, receiverRank = -1, receivedRank = -1;
     int rank;
@@ -604,14 +604,14 @@ double MoveCreator::replicaExchangeMove(long sweep) {
 
                 localmpi.accepted = receivedmpi.accepted;
 
-                edriftchanges += sim->press * (receivedmpi.volume - localmpi.volume) - (double)conf->pvec.size() * log(receivedmpi.volume / localmpi.volume) / sim->temper;
+                edriftchanges += sim->press * (receivedmpi.volume - localmpi.volume) - (double)conf->pvec.size() * log(receivedmpi.volume / localmpi.volume) * sim->temper;
 
                 sim->temper = receivedmpi.temperature;
                 sim->press = receivedmpi.press;
                 sim->pseudoRank = receivedmpi.pseudoMpiRank;
 
                 volume = conf->geo.volume();
-                edriftchanges += (sim->press * volume - (double)conf->pvec.size() * log(volume) / sim->temper) - entrophy;
+                edriftchanges += (sim->press * volume - (double)conf->pvec.size() * log(volume) * sim->temper) - entrophy;
 
             } else {
                 sim->stat.mpiexch.rej++;
@@ -673,7 +673,7 @@ double MoveCreator::replicaExchangeMove(long sweep) {
             if ( (!(reject)) && ( (change > 0) || (ran2() < exp(change))  ) ) { // Exchange ACCEPTED send local stuff
                 localmpi.accepted = 1;
 
-                edriftchanges += sim->press * (receivedmpi.volume - localmpi.volume) - (double)conf->pvec.size() * log(receivedmpi.volume / localmpi.volume) / sim->temper;
+                edriftchanges += sim->press * (receivedmpi.volume - localmpi.volume) - (double)conf->pvec.size() * log(receivedmpi.volume / localmpi.volume) * sim->temper;
 
                 // change temperature and pseudorank
                 sim->temper = receivedmpi.temperature;
@@ -681,7 +681,7 @@ double MoveCreator::replicaExchangeMove(long sweep) {
                 sim->pseudoRank = receivedmpi.pseudoMpiRank;
 
                 volume = conf->geo.volume();
-                edriftchanges += (sim->press * volume - (double)conf->pvec.size() * log(volume) / sim->temper) - entrophy;
+                edriftchanges += (sim->press * volume - (double)conf->pvec.size() * log(volume) * sim->temper) - entrophy;
 
                 if ( wl.wlm[0] > 0 ) {
                     for (int wli=0;wli<wl.wlmdim;wli++) {
@@ -730,7 +730,7 @@ double MoveCreator::muVTMove() {
 
     Molecule target;
     double volume = conf->geo.volume();
-    double entrophy = log(volume)/sim->temper;
+    double entrophy = log(volume)*sim->temper;
     double energy = 0.0;
     unsigned int molSize=0;
     Vector displace;

--- a/scOOP/mc/updater.cpp
+++ b/scOOP/mc/updater.cpp
@@ -105,7 +105,7 @@ void Updater::simulate(long nsweeps, long adjust, long paramfrq, long report) {
     edriftstart = calcEnergy.allToAll(calcEnergy.eMat.energyMatrix);     // Energy drift calculation - start
 
     double volume = conf->geo.volume();          // volume of geo.box
-    const double pvdriftstart = sim->press * volume - (double)conf->pvec.size() * log(volume) / sim->temper;    // PV drift calculation - start
+    const double pvdriftstart = sim->press * volume - (double)conf->pvec.size() * log(volume) * sim->temper;    // PV drift calculation - start
 
     /********************************************************/
     /*                 Simulation Loop                      */
@@ -116,7 +116,7 @@ void Updater::simulate(long nsweeps, long adjust, long paramfrq, long report) {
         if(nsweeps>=10 && sweep%(nsweeps/10) == 0 && !mpi) {
             volume = conf->geo.volume();
             edriftend = calcEnergy.allToAll();
-            pvdriftend =  sim->press * volume - (double)conf->pvec.size() * log(volume) / sim->temper;
+            pvdriftend =  sim->press * volume - (double)conf->pvec.size() * log(volume) * sim->temper;
             time = clock()-time;
             cout << "sweep: " << sweep << " particles: " << conf->pvec.size()
                  << " drift: " << edriftend - edriftstart - edriftchanges +pvdriftend -pvdriftstart;
@@ -315,7 +315,7 @@ void Updater::simulate(long nsweeps, long adjust, long paramfrq, long report) {
     //do energy drift check - at the end calculation
     volume = conf->geo.volume();
     edriftend = calcEnergy.allToAll();
-    pvdriftend =  sim->press * volume - (double)conf->pvec.size() * log(volume) / sim->temper;
+    pvdriftend =  sim->press * volume - (double)conf->pvec.size() * log(volume) * sim->temper;
     if(sim->mpinprocs > 1) {
         printf("%d Energy drift: %.5e \n", sim->pseudoRank, edriftend - edriftstart - edriftchanges +pvdriftend -pvdriftstart);
         /*printf("%d Starting energy: %.8f \n", sim->pseudoRank, edriftstart);


### PR DESCRIPTION
Well mistake was only fixed in PressureMove ... so that if u used temperature other then 1.0 then drift calculation was off due to old(wrong) calculation ... despite simulations were ok. Now (hopefully) all instances of wrong use of temperature were corrected.